### PR TITLE
Feedback

### DIFF
--- a/feedback/env-anywhere-def.R
+++ b/feedback/env-anywhere-def.R
@@ -1,0 +1,25 @@
+#' which parent environments of <env> contain <name>?
+#' inputs:
+#'    name: a variable name
+#'    env: valid inputs for pryr:::to_env, defaults to the calling frame
+#' output: a list of environments containing <name>
+anywhere <- function(name, env = parent.frame()) {
+  checkmate::assert_string(name, min.chars = 1)
+  #to_env takes care of checks for <env> and conversions to environments
+  # (input checking & homogenization)
+  env <- pryr:::to_env(env)
+
+  result <- list()
+  # base case: terminate recursion in emptyenv and return empty list
+  if (identical(env, emptyenv())) {
+    return(list())
+  }
+  # success: if <name> is in current <env>, <env> is added to results list ...
+  if (exists(name, env, inherits = FALSE)) {
+    result <- append(result, env)
+  }
+  # .... and then we go up one level to the next environment and add what we
+  #      find there to the list
+  # (recursion)
+  append(result, anywhere(name, parent.env(env)))
+}

--- a/feedback/env-sol.Rmd
+++ b/feedback/env-sol.Rmd
@@ -1,0 +1,56 @@
+<!--
+Knitten Sie dieses File in RStudio zur besseren Lesbarkeit, bitte...
+-->
+
+```{r, child = "env-ex.Rmd"}
+```
+
+----------------------------------------------------
+
+### Lösung:
+
+a) 
+
+* alle Objekte in `environment` müssen Namen haben, Listen können unbenamte Einträge haben.
+* Objekte in einem `environment` haben keine Reihenfolge/Topologie, Einträge in einer Liste schon.
+* Jedes `environment` hat eine Elternumgebung
+* `environment`s haben *reference semantics*: D.h. das im `environment` hinterlegte *binding* eines Symbols (also: des Namens einer Variable) an einen Wert wird nur über den Speicherort dieses Werts repräsentiert (also: ein bestimmtes Symbol verweist auf -- *referenziert* -- eine Adresse im Speicher). Das heißt:
+    - ein und das selbe Objekt/der selbe Wert kann Element mehrer `environments` sein, unter möglicherweise unterschiedlichen Namen die aber eben alle den selben Speicherort referenzieren! 
+    - Modifikation eines `environment` erzeugt keine Kopie der im `environment` an Symbole gebundenen Werte (also: kein *copy-on-modify* wie bei anderen R Objekten).
+
+b) 
+
+In der Umgebung aus der sie aufgerufen wurden, siehe `?ls` bzw. `?rm`.
+
+c) 
+
+Siehe `help("<-"), help("<<-")`. 
+
+`<-` legt eine neue `binding` (eine Verknüpfung zwischen einem Symbol für eine Variable und dem Speicherort wo der Wert der Variable ) in der Umgebung in der `<-` aufgerufen wurde an, bzw. ersetzt eine alte Zuweisung für die Variable auf der linken Seite. 
+
+Das Verhalten von `<<-` hängt davon ab ob/wo eine Variable durch das Symbol auf der linken Seite bereits definiert ist. Falls die Variable in der aufrufenden Umgebung nicht definiert ist, sucht `<<-` die Vorfahrenumgebungen der aufrufenden Umgebung ab und ersetzt die Zuweisung in der ersten Vorfahrenumgebung in der die Variable definiert ist. Ist sie nirgends definiert (oder bereits bestehende `binding`s sind `locked`, also nicht überschreibbar) so wird eine neue Variable im `.GlobalEnv` angelegt.
+
+d)
+
+Mit Rekursion (Funktion `anywhere()` ruft sich immer wieder selbst auf):
+```{r, def_anywhere, code = readLines("env-anywhere-def.R"), echo = FALSE}
+```
+Äquivalent ohne Rekursion:
+```{r, def_anywhere_sequential, eval=FALSE}
+anywhere <- function(name, env = parent.frame()) {
+  checkmate::assert_string(name)
+  env <- pryr:::to_env(env)
+  result <- list()
+  while (!identical(env, emptyenv())) {
+    if (exists(name, env, inherits = FALSE)) {
+      result <- append(result, env)
+    }
+    env <- parent.env(env)
+  }
+  result
+}
+```
+
+```{r, test-anywhere, eval = TRUE, code=readLines("test-env-anywhere.R")}
+```
+Sie fragen vielleicht warum hier auch eine Variable "`t`" gefunden wird, die in der Umgebung, die mit dem `base`-Paket assoziiert ist, liegt...? Da haben wir doch gar nix angelegt...? Das ist die Funktion mit der Matrizen und Vektoren transponiert werden! 


### PR DESCRIPTION
@muskuloes 

not bad, but there's room for improvement...


- "Environments are not copied when modified" 
well, yeah, that's kind of true (more precisely: "the values bound to symbols in an environment are not copied when the environment is modified"), but not the entire story. R environments have *reference semantics* which has more consequences that that -- c.f. solution. 

- https://github.com/fort-w2021/env-ex-muskuloes/blob/fa8b3735ba4895192e66c3cd1e70c44bcd034b74/env-sol.Rmd#L36
also needs to be a non-empty, non-NA string. be more paranoid! 

- https://github.com/fort-w2021/env-ex-muskuloes/blob/fa8b3735ba4895192e66c3cd1e70c44bcd034b74/env-sol.Rmd#L41-L44
nope, BUG, this needs to be removed.  happens to give valid answers in the unit tests but not in general (why would it? you're assuming **every** symbol is bound in the global environment and in the base package, here....) - e.g:
```r
> rm(list = ls()) # clean workspace (don't execute if you're working on something important!!)
> e0 <- list2env(list(t = 0))
> e1 <- list2env(list(x = 1))
> e2 <- list2env(list(t = 2))
> parent.env(e0) <- e1
> parent.env(e1) <- e2
> 
> # source your anywhere() definition
> anywhere("x", e0)
[[1]]
<environment: 0x5633865cbd48>

[[2]]
<environment: R_GlobalEnv>

[[3]]
<environment: base>

> 
> e1
<environment: 0x5633865cbd48>
```
correct answer here would have been just `e1`